### PR TITLE
Fix conditional statement in validate-infra.yaml

### DIFF
--- a/.github/workflows/validate-infra.yaml
+++ b/.github/workflows/validate-infra.yaml
@@ -29,7 +29,7 @@ jobs:
           tools: templateanalyzer
 
       - name: Upload alerts to Security tab
-        if: github.repository == 'Azure-Samples/azure-search-openai-javascript'
+        if: github.repository_owner == 'Azure-Samples'
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
The bicep analyzer isn't being run because it had a conditional copied from another repo with a different name, this makes it generic to avoid that happening again